### PR TITLE
Allow for the original attribute to update editor model when content is updated in a diff editor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,10 @@ export default {
       this.editor && this.value !== this._getValue() && this._setValue(this.value);
     },
 
+    original() {
+      this.editor && this._setModel(this.value, this.original);
+    },
+
     language() {
       if(!this.editor) return;
       if(this.diffEditor){      //diff模式下更新language


### PR DESCRIPTION
This will allow the diff editor to be used in situations where we want to compare multiple versions of the files/content and we need to refresh what the "original" content is. 